### PR TITLE
Support short/long-plural-form

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -42,6 +42,8 @@ Beyond the minimum, each acronym can define:
     Defaults to ‘s’.
 -   ``long-plural``: The plural ending of the long form.
     Defaults to ‘s’.
+-   ``short-plural-form``: The plural short form of the acronym; replaces the short form when used instead of appending the plural ending.
+-   ``long-plural-form``: Plural long form of the acronym; replaces the long form when used instead of appending the plural ending.
 
 An example metadata block would be:
 

--- a/pandocacro/translate.py
+++ b/pandocacro/translate.py
@@ -117,9 +117,14 @@ def plain(key: keys.Key, acronyms: PandocAcro) -> panflute.Str:
     long_ = acronyms[key.value]["long"] + (
         acronyms[key.value].get("long-plural", "s") if key.plural else ""
     )
+    if key.plural and acronyms[key.value].get("long-plural-form"):
+        long_ = acronyms[key.value].get("long-plural-form")
+
     short_ = acronyms[key.value]["short"] + (
         acronyms[key.value].get("short-plural", "s") if key.plural else ""
     )
+    if key.plural and acronyms[key.value].get("short-plural-form"):
+        short_ = acronyms[key.value].get("short-plural-form")
 
     def get_style(option: str, default: str) -> Tuple[str, bool]:
         style = acronyms.options.get(option, default)

--- a/tests/example.md
+++ b/tests/example.md
@@ -14,3 +14,6 @@
 -   [+afaik]{.caps .long .plural}
 -   [+afaik]{.caps .full}
 -   [+afaik]{.caps .full .plural}
+  - [+BR]{.full .plural}
+-   [+BR]{.short .plural}
+-   [+BR]{.long .plural}

--- a/tests/metadata.yaml
+++ b/tests/metadata.yaml
@@ -8,4 +8,9 @@ acronyms:
     long: laugh out loud
     short-plural: es  # Contrived for example purposes
     long-plural: es   # Contrived for example purposes
+  BR:
+    short: BR
+    long: Betriebsrat
+    short-plural-form: BRs
+    long-plural-form: Betriebsräte
 ...

--- a/tests/test_header.py
+++ b/tests/test_header.py
@@ -5,6 +5,12 @@ import os
 import panflute
 
 _expected = r"""\usepackage{acro}
+\DeclareAcronym{BR}{
+short = BR,
+long = Betriebsrat,
+long-plural-form = Betriebsräte,
+short-plural-form = BRs
+}
 \DeclareAcronym{afaik}{
 short = AFAIK,
 long = as far as I know

--- a/tests/test_latex.py
+++ b/tests/test_latex.py
@@ -23,6 +23,12 @@ _macros = [f"\\item\n  \\{s}{{afaik}}" for s in (
         "Acfp",
     )
 ]
+_macros.extend([f"\\item\n  \\{s}{{BR}}" for s in (
+        "acfp",
+        "acsp",
+        "aclp",
+    )
+])
 
 _expected = "\n".join([
     r"\begin{itemize}",

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -21,6 +21,9 @@ _expected = "\n".join("-   " + s for s in (
     "As far as I knows",
     "As far as I know (AFAIK)",
     "As far as I knows (AFAIK)",
+    "Betriebsräte (BR)",
+    "BRs",
+    "Betriebsräte",
     )
 )
 


### PR DESCRIPTION
- Adds tests for `short-plural-form` and `long-plural-form`.
- Implements `short-plural-form` and `long-plural-form` for markdown (already implemented for LaTeX)
- Updates the documentation

As this is my first contact with python, you might have a closer look at the code ;-)